### PR TITLE
util.js updates + file blacklist extension

### DIFF
--- a/file_blacklist.json
+++ b/file_blacklist.json
@@ -3,5 +3,11 @@
     ".bat",
     ".cmd",
     ".ps1",
-    ".sh"
+    ".sh",
+    ".vbs",
+    ".com",
+    ".lnk",
+    ".reg",
+    ".vb",
+    ".msi",
 ]

--- a/src/util.js
+++ b/src/util.js
@@ -42,9 +42,9 @@ function getPerm(member, boolHelp=false) {
         return true;
     } else if (member.guild.ownerID == member.id) {
         return true;
-    } else {
-        return false;
     }
+    
+    return false;
 }
 
 /**
@@ -56,20 +56,21 @@ function getPerm(member, boolHelp=false) {
  * @returns {string}
  */
 function getReason(args, target, startIndex=0) {
-    const name = `<@!${target.id}>`;
-    const id = `${target.id}`;
-    let reason = "";
-
-    for (let i = startIndex; i < args.length; i++) {
-        if (args[i].indexOf(name) == -1) {
-            if (args[i].indexOf(id) == -1)
-                reason += `${args[i]} `;
-            else
-                reason += `${args[i].substr(id.length)} `;
-        } else
-            reason += `${args[i].substr(name.length)} `;
+    // since a command is always going to call getReason() after parsing the other
+    // args out (for example, time muted comes before the reason, as in:
+    //      .mute <@!targetid> 2h spamming off topic
+    // all we need to do is slice the array at the starting index of the reason
+    // and join them with spaces to replicate how it was actually typed so it
+    // reads well.
+    if ( args.length >= startIndex )
+    {
+        return args.slice(startIndex).join(' ').trim();
     }
-    return reason.trim();
+    
+    // however, if the args array is not large enough to accommodate startIndex,
+    // we know a reason wasn't provided, and we can just return an empty string
+    // for the command itself to handle
+    return "";
 }
 
 /**
@@ -95,7 +96,7 @@ async function filterAttachment(message) {
     if (abuseAttachement !== undefined) {
         return message.delete()
             .then(msg => {
-                msg.channel.send(`Sorry ${msg.author.tag}, I deleted that file because it's file-type `
+                msg.channel.send(`Sorry ${msg.author.tag}, I deleted that file because its file-type `
                     + "is blacklisted in our spam filter")
                 return true;
             });


### PR DESCRIPTION
- Added a handful of common executable filetypes to file_blacklist
- (I believe) resolved the issue with util::getReason() returning the last few digits of a discord ID when no reason is provided for a command
- I had to fix that unnecessary else at the end of util::getPerm()
- Small grammar thing in util::filterAttachment()